### PR TITLE
Add `uint256[]` support

### DIFF
--- a/src/ExampleClone.huff
+++ b/src/ExampleClone.huff
@@ -24,12 +24,23 @@
     0x20 0x00 return
 }
 
+#define macro PARAM_5() = takes (0) returns (0) {
+    0x04 calldataload           // [arr_len]
+    dup1 0x00                   // [0x00, arr_len, arr_len]
+    GET_ARG_UINT_256_ARR()      // [ptr, arr_len]
+    swap1                       // [arr_len, ptr]
+    0x20 mul                    // [arr_len * 0x20, ptr]
+    0x40 add                    // [arr_len * 0x20 + 0x40, ptr]
+    swap1 return
+}
+
 #define macro MAIN() = takes (0) returns (0) {
     0x00 calldataload 0xE0 shr
     dup1 0x02d91518 eq param1 jumpi
     dup1 0x1f049b68 eq param2 jumpi
     dup1 0x5ccea9a5 eq param3 jumpi
     dup1 0xe79876ff eq param4 jumpi
+    dup1 0xf0b032e2 eq param5 jumpi
 
     param1:
         PARAM_1()
@@ -39,4 +50,6 @@
         PARAM_3()
     param4:
         PARAM_4()
+    param5:
+        PARAM_5()
 }

--- a/src/ExampleCloneFactory.huff
+++ b/src/ExampleCloneFactory.huff
@@ -38,12 +38,41 @@
         0x00 0x00 revert
 }
 
+/// @notice Creates an `ExampleClone` contract that has an immutable
+/// uint256 array
+#define macro CREATE_ARRAY_CLONE() = takes (0) returns (0) {
+    0x24 calldataload   // [arr_len]
+    0x20 mul            // [arr_len * 0x20]
+    0x20 add            // [arr_len * 0x20 + 0x20]
+    0x24                // [0x24, arr_len * 0x20 + 0x20]
+    0x300               // [0x300, 0x24, arr_len * 0x20 + 0x20]
+    calldatacopy        // []
+
+    // Set data length in bytes
+    0x300 dup1          // [0x300, 0x300]
+    mload               // [arr_len, 0x300]
+    0x20 mul            // [arr_len * 0x20, 0x300]
+    0x300 mstore        // [0x300 (data_ptr)]
+
+    [IMPL] sload        // [impl_addr, data_ptr]
+
+    CLONE(err)          // [instance]
+    0x00 mstore         // []
+    0x20 0x00 return
+
+    err:
+        0x00 0x00 revert
+}
+
 #define macro MAIN() = takes (0) returns (0) {
     0x00 calldataload 0xE0 shr
     dup1 0x684fbe55 eq clone jumpi
+    dup1 0x2bbb631e eq arr_clone jumpi
 
     clone:
         CREATE_CLONE()
+    arr_clone:
+        CREATE_ARRAY_CLONE()
 }
 
 #define macro CONSTRUCTOR() = takes (0) returns (0) {

--- a/src/HuffClone.huff
+++ b/src/HuffClone.huff
@@ -24,53 +24,44 @@
 /// @param argOffset The offset of the arg in the packed data
 /// @param arrLen Number of elements in the array
 /// @return arr The beginning location of the array in memory
-// TODO: Finish / Test
 #define macro GET_ARG_UINT_256_ARR() = takes (2) returns (1) {
     // Initial Stack: // [argOffset, arrLen]
     GET_IMMUTABLE_ARGS_OFFSET() // [offset, argOffset, arrLen]
 
-    0x00 0x00 mstore  // [offset, argOffset, arrLen]
-    // Write array length to memory at slot 0x20
-    dup3 0x20 mstore  // [offset, argOffset, arrLen]
+    // Push loop index to stack
+    0x00              // [loop_index, offset, argOffset, arrLen]
+
     loop_body:
-        0x00 mload    // [loop_index, offset, argOffset, arrLen] 
-        
-        // Check if loop is complete
-        dup4          // [arrLen, loop_index, offset, argOffset, arrLen] 
-        dup2          // [loop_index, arrLen, loop_index, offset, argOffset, arrLen]
-        lt            // [loop_index < arrLen, loop_index, offset, argOffset, arrLen]
-        iszero finish jumpi  // If the loop index is >= to the array index, the loop is complete.
+        dup4 dup2     // [loop_index, arrLen, loop_index, offset, argOffset, arrLen]
+        lt iszero     // [loop_index >= arrLen, loop_index, offset, argOffset, arrLen]
+        finish jumpi
 
-        0x20          // [0x20, loop_index, offset, argOffset, arrLen]
-        mul           // [0x20 * loop_index, offset, argOffset, arrLen]
+        dup1          // [loop_index, loop_index, offset, argOffset, arrLen]
+        0x20 mul      // [loop_index * 0x20, loop_index, offset, argOffset, arrLen]
 
-        // Load array element from calldata
-        dup2          // [offset, 0x20 * loop_index, offset, argOffset, arrLen]
-        dup4          // [argOffset, offset, 0x20 * loop_index, offset, argOffset, arrLen]
-        add           // [argOffset + offset, 0x20 * loop_index, offset, argOffset, arrLen]
-        add           // [argOffset + offset + 0x20 * loop_index, offset, argOffset, arrLen]
-        calldataload  // [cd, offset, argOffset, arrLen]
+        dup3 dup5     // [argOffset, offset, loop_index * 0x20, loop_index, offset, argOffset, arrLen]
+        add           // [offset + argOffset, loop_index * 0x20, loop_index, offset, argOffset, arrLen]
+        add           // [offset + argOffset + loop_index * 0x20, loop_index, offset, argOffset, arrLen]
+        calldataload  // [element, loop_index, offset, argOffset, arrLen]
 
-        // Store element at next 32 byte offset in memory
-        // ((loop_index + 1) * 0x20) + 0x20
-        // nasty rn
-        0x00 mload    // [loop_index, cd, offset, argOffset, arrLen]
-        dup1          // [loop_index, loop_index, cd, offset, argOffset, arrLen]
-        0x01 add      // [loop_index + 1, loop_index, cd, offset, argOffset, arrLen]
-        0x20 mul      // [(loop_index + 1) * 0x20, loop_index, cd, offset, argOffset, arrLen]
-        0x20 add      // [((loop_index + 1) * 0x20) + 0x20, loop_index, cd, offset, argOffset, arrLen]
-        swap2         // [cd, ((loop_index + 1) * 0x20) + 0x20, loop_index, offset, argOffset, arrLen]
-        swap1         // [((loop_index + 1) * 0x20) + 0x20, cd, loop_index, offset, argOffset, arrLen]
+        dup2          // [loop_index, element, loop_index, offset, argOffset, arrLen]
+        0x20 mul      // [loop_index * 0x20, element, loop_index, offset, argOffset, arrLen]
+        0x40 add      // [loop_index * 0x20 + 0x20, element, loop_index, offset, argOffset, arrLen]
         mstore        // [loop_index, offset, argOffset, arrLen]
 
-        0x01          // [0x01, loop_index, offset, argOffset, arrLen]
-        add           // [0x01 + loop_index, offset, argOffset, arrLen]
-        0x00 mstore   // [offset, argOffset, arrLen]
+        0x01 add      // [loop_index + 1, offset, argOffset, arrLen]
 
-        0x01 loop_body jumpi
+        loop_body jump
     finish:
-        pop pop pop   // [] - Clear the stack
-        0x20          // [0x20] - Beginning location of the array in memory
+        // Set arr size
+        0x20 mstore   // [offset, argOffset, arrLen]
+
+        // Set arr element size (0x20)
+        0x20 0x00 mstore
+
+        // Clean stack & return mem ptr to array
+        pop pop pop   // []
+        0x00          // [0x00] - Beginning offset of the array in memory
 }
 
 /// @notice Reads an immutable arg with type uint64

--- a/test/HuffClone.t.sol
+++ b/test/HuffClone.t.sol
@@ -7,12 +7,20 @@ import {IExampleClone, IExampleCloneFactory} from "./Interfaces.sol";
 
 contract ExampleCloneTest is Test {
     IExampleClone internal clone;
+    IExampleClone internal arrClone;
     IExampleCloneFactory internal factory;
 
     function setUp() public {
         IExampleClone impl = IExampleClone(HuffDeployer.deploy("ExampleClone"));
         factory = IExampleCloneFactory(HuffDeployer.deploy_with_args("ExampleCloneFactory", abi.encode(address(impl))));
+        
         clone = IExampleClone(factory.createClone(address(this), type(uint256).max, 8008, 69));
+
+        uint256[] memory a = new uint256[](5);
+        for (uint i; i < 5; ++i) {
+            a[i] = 256;
+        }
+        arrClone = IExampleClone(factory.createArrClone(a));
     }
 
     /// -----------------------------------------------------------------------
@@ -33,5 +41,9 @@ contract ExampleCloneTest is Test {
 
     function testGas_param4() public view {
         clone.param4();
+    }
+
+    function testGas_param5() public {
+        arrClone.param5(5);
     }
 }

--- a/test/HuffCloneFactory.t.sol
+++ b/test/HuffCloneFactory.t.sol
@@ -28,6 +28,23 @@ contract HuffCloneFactoryTest is Test {
         factory.createClone(param1, param2, param3, param4);
     }
 
+    function testGas_arrClone(
+        uint256 a,
+        uint256 b,
+        uint256 c,
+        uint256 d,
+        uint256 e
+    ) public {
+        uint256[] memory arr = new uint256[](5);
+        arr[0] = a;
+        arr[1] = b;
+        arr[2] = c;
+        arr[3] = d;
+        arr[4] = e;
+
+        factory.createArrClone(arr);
+    }
+
     /// -----------------------------------------------------------------------
     /// Correctness tests
     /// -----------------------------------------------------------------------
@@ -48,5 +65,23 @@ contract HuffCloneFactoryTest is Test {
         assertEq(clone.param2(), param2);
         assertEq(clone.param3(), param3);
         assertEq(clone.param4(), param4);
+    }
+
+    function testCorrectness_arrClone(
+        uint256 a,
+        uint256 b,
+        uint256 c,
+        uint256 d,
+        uint256 e
+    ) public {
+        uint256[] memory arr = new uint256[](5);
+        arr[0] = a;
+        arr[1] = b;
+        arr[2] = c;
+        arr[3] = d;
+        arr[4] = e;
+
+        IExampleClone clone = IExampleClone(factory.createArrClone(arr));
+        assertEq(clone.param5(arr.length), arr);
     }
 }

--- a/test/Interfaces.sol
+++ b/test/Interfaces.sol
@@ -6,6 +6,7 @@ interface IExampleClone {
     function param2() external pure returns (uint256);
     function param3() external pure returns (uint64);
     function param4() external pure returns (uint8);
+    function param5(uint256 arrLen) external pure returns (uint256[] memory);
 }
 
 interface IExampleCloneFactory {
@@ -15,4 +16,6 @@ interface IExampleCloneFactory {
         uint64 param3,
         uint8 param4
     ) external returns (address clone);
+
+    function createArrClone(uint256[] memory arr) external returns (address clone);
 }


### PR DESCRIPTION
# Overview

Adds support for retrieving `uint256` arrays from the clone's immutable arguments.